### PR TITLE
Add transaction to create batch POST

### DIFF
--- a/api/lib/utils.js
+++ b/api/lib/utils.js
@@ -22,7 +22,7 @@ var when = require("when");
 var handleWriteErr = function (req, res) {
   return function (err) {
     // If validation err respond and don't end process
-    if (err.message = "SequelizeValidationError") {
+    if (err.name === "SequelizeValidationError") {
       return res(err.errors).code(400);
     }
 
@@ -35,7 +35,7 @@ var handleWriteErr = function (req, res) {
 
       res(err.message).code(500);
     } catch (e) {
-      global.console.log.error(err);
+      global.console.error(err);
     } finally {
       process.exit(1);
     }

--- a/api/routes/surveys.js
+++ b/api/routes/surveys.js
@@ -15,33 +15,37 @@ module.exports = function (server) {
     method: "POST",
     path: "/surveys/batch",
     handler: function (req, res) {
-      // TODO[6]: Verify data
       var surveys = req.payload;
       var models = req.server.plugins.sqlModels.models;
       var batchId;
 
-      // First create a batch number
-      models.SurveyBatch.create()
-        // Then create the survey records
-        // and response records
-        .then(function (batch) {
-          batchId = batch.get("id");
+      // Wrap in transaction. If promise chain err's
+      // then transaction rolled back automatically
+      // If succeeds then committed
+      models.sqlize.transaction(function () {
+        // First create a batch number
+        return models.SurveyBatch.create()
+          // Then create the survey records
+          // and response records
+          .then(function (batch) {
+            batchId = batch.get("id");
 
-          return when.all(_.map(surveys, function (survey) {
-            return utils.createSurvey(_.extend(survey, {
-              SurveyBatchId: batchId
-            }), models);
-          }));
-        })
-
-        // Fetch all newly created surveys joined to new responses
-        // and create resonse object
-        .then(function () {
-          return utils.batchResponse(batchId, models);
-        })
-        .then(function (responseBody) {
-          res(responseBody);
-        })
+            return when.all(_.map(surveys, function (survey) {
+              return utils.createSurvey(_.extend(survey, {
+                SurveyBatchId: batchId
+              }), models);
+            }));
+          })
+          // Fetch all newly created surveys joined to new responses
+          // and create resonse object
+          .then(function () {
+            return utils.batchResponse(batchId, models);
+          })
+          .then(function (responseBody) {
+            return res(responseBody);
+          });
+      })
+        // If catch then transaction will have been rolled back
         .catch(utils.handleWriteErr(req, res));
     }
   });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "moment": "2.8.3",
     "mysql": "2.5.2",
     "recluster": "0.3.7",
-    "sequelize": "2.0.0-rc2",
+    "sequelize": "git+https://github.com/little-big-h/sequelize.git#ae799bfc1ab3df629d689b58f47d51f45179bca7",
     "sqlite3": "3.0.2",
     "when": "3.5.2"
   },


### PR DESCRIPTION
@ryan-roemer 
Fixes #15 

Added Sequelize transaction for the one route that requires multiple table inserts. The transaction commits automatically if the promise returned resolves! 

Note that there is an open PR on Sequelize to fix a bug where transactions don't work with sqlite in memory. I've pinned our dependency to the head of this PR and created an issue to check back and update the dependency when the PR is merged.

PR: https://github.com/sequelize/sequelize/pull/2380
